### PR TITLE
Fix trvae paper link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # trVAE [![PyPI version](https://badge.fury.io/py/trVAE.svg)](https://badge.fury.io/py/trVAE) [![Build Status](https://travis-ci.org/theislab/trVAE.svg?branch=master)](https://travis-ci.org/theislab/trVAE) [![Downloads](https://pepy.tech/badge/trvae)](https://pepy.tech/project/trvae)
 
-*Conditional out-of-distribution generation for unpaired data using transfer VAE [(Bioinformatics, 2020)](https://genomebiology.biomedcentral.com/articles/10.1186/s13059-019-1663-x).*
+*Conditional out-of-distribution generation for unpaired data using transfer VAE [(Bioinformatics, 2020)](https://doi.org/10.1093/bioinformatics/btaa800).*
 
 
 <img align="center" src="./sketch/sketch.png?raw=true">


### PR DESCRIPTION
Right now it's pointing to the PAGA paper.